### PR TITLE
ci: report tests + coverage to self-hosted UniTrack

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -43,5 +43,17 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ github.workspace }}/**/surefire-reports/TEST-*.xml
 
+      # Report test + coverage trends to the self-hosted UniTrack (alongside Codecov).
+      # soft-fail so reporting never breaks the build; the uploader gzips the multi-module payload.
+      - name: Report tests + coverage to UniTrack
+        if: always()
+        uses: alexmond/unitrack/action@v0
+        with:
+          url: ${{ vars.UNITRACK_URL }}
+          token: ${{ secrets.UNITRACK_TOKEN }}
+          junit: '**/surefire-reports/TEST-*.xml'
+          jacoco: '**/jacoco.xml'
+          soft-fail: "true"
+
       - name: Submit Dependency Snapshot
         uses: advanced-security/maven-dependency-submission-action@v5


### PR DESCRIPTION
Adds the `alexmond/unitrack/action@v0` uploader alongside Codecov — publishes surefire + jacoco to https://unitrack.alexmond.org on every build. `soft-fail` so reporting never breaks the gate. Repo var `UNITRACK_URL` + secret `UNITRACK_TOKEN` (INGEST-scoped) already set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)