### PR TITLE
ci: builder pipeline analogs

### DIFF
--- a/.builder/pipelines/ci.yml
+++ b/.builder/pipelines/ci.yml
@@ -1,0 +1,19 @@
+name: Java CI with Maven
+
+# Analog of .github/workflows/maven.yml.
+# GitHub push/pull_request on main -> builder push + manual triggers.
+on: [push, manual]
+push:
+  branches: [main]
+
+jobs:
+  build:
+    image: maven:3.9-eclipse-temurin-21
+    cache:
+      key: m2-actuator-extensions
+      paths: [.m2/repository]
+    steps:
+      - name: Checkout
+        run: git clone --depth 1 https://github.com/alexmond/spring-boot-actuator-extensions.git .
+      - name: Build with Maven
+        run: mvn -B package --file pom.xml -Pdefault --no-transfer-progress -Dmaven.repo.local=.m2/repository

--- a/.builder/pipelines/release.yml
+++ b/.builder/pipelines/release.yml
@@ -1,0 +1,52 @@
+name: Maven Release
+
+# Analog of .github/workflows/maven_release.yml (workflow_dispatch).
+# Maven Central deploy with version set/bump, tag, and push-back.
+on: [manual]
+
+inputs:
+  branch:
+    type: string
+    description: Branch to release from
+    default: main
+    required: true
+  releaseVersion:
+    type: string
+    description: Release version
+    required: true
+  nextVersion:
+    type: string
+    description: Next development version (with -SNAPSHOT suffix)
+    required: true
+
+jobs:
+  release:
+    image: maven:3.9-eclipse-temurin-21
+    cache:
+      key: m2-actuator-extensions
+      paths: [.m2/repository]
+    secrets: [OSSRH_USERNAME, OSSRH_PASSWORD, GPG_PRIVATE_KEY, GPG_PASSPHRASE]
+    steps:
+      - name: Checkout
+        run: git clone https://github.com/alexmond/spring-boot-actuator-extensions.git . && git checkout "$branch"
+      - name: Configure Git
+        run: |
+          git config user.name "builder"
+          git config user.email "actions@github.com"
+          git config credential.helper store
+      - name: Set release version
+        run: mvn versions:set -DnewVersion="$releaseVersion" -Pdefault --no-transfer-progress -Dmaven.repo.local=.m2/repository
+      - name: Verify build
+        run: mvn --batch-mode verify -Pdefault --no-transfer-progress -Dmaven.repo.local=.m2/repository
+      - name: Commit and tag release
+        run: |
+          git commit -am "Prepare release $releaseVersion"
+          git tag -a "$releaseVersion" -m "Release $releaseVersion"
+      - name: Deploy to Maven Central
+        run: mvn --batch-mode clean deploy -Prelease -Dgpg.passphrase="$GPG_PASSPHRASE" --no-transfer-progress -Dmaven.repo.local=.m2/repository
+      - name: Set next development version
+        run: |
+          mvn versions:set -DnewVersion="$nextVersion" -Pdefault --no-transfer-progress -Dmaven.repo.local=.m2/repository
+          git commit -am "Prepare for next development iteration: $nextVersion"
+      - name: Push changes
+        run: git push origin "$branch" && git push origin --tags


### PR DESCRIPTION
Adds builder (`.builder/pipelines/*.yml`) analogs of the two GitHub Actions workflows, so the same build/release flows can run on builder:

- `ci.yml` — mirrors `maven.yml`: runs `mvn -B package -Pdefault` on push to main (plus manual), with a Maven dependency cache.
- `release.yml` — mirrors `maven_release.yml`: manual trigger taking `branch` / `releaseVersion` / `nextVersion` inputs; sets the release version, verifies, deploys to Maven Central, bumps to the next snapshot, tags, and pushes.

These are additive and inert — they do not touch or replace the existing GitHub Actions workflows.

Translation gaps (builder has no direct equivalent yet, so they were dropped):
- Codecov upload, test-result publishing, and the dependency-submission step (external reporters, not core build).
- GitHub Release creation (`softprops/action-gh-release`) — no Pages/release primitive.
- Release uses `maven:3.9-eclipse-temurin-21`; the GHA workflows pin JDK 17. Adjust the image if a 17 toolchain is required.
- Git push-back in the release job relies on a configured credential helper rather than an inline token URL.